### PR TITLE
feat: Display 'In stock' for products that are always available

### DIFF
--- a/backend-api/app/Models/Product.php
+++ b/backend-api/app/Models/Product.php
@@ -20,7 +20,8 @@ class Product extends Model
         'wholesale_threshold',
         'stock',
         'image',
-        'is_active'
+        'is_active',
+        'is_always_in_stock'
     ];
 
     protected $casts = [
@@ -29,7 +30,8 @@ class Product extends Model
         'wholesale_price' => 'decimal:2',
         'wholesale_threshold' => 'integer',
         'stock' => 'integer',
-        'is_active' => 'boolean'
+        'is_active' => 'boolean',
+        'is_always_in_stock' => 'boolean'
     ];
 
     // Add price and image_url to appends so they're included in JSON responses

--- a/backend-api/database/migrations/2025_07_09_000000_add_is_always_in_stock_to_products_table.php
+++ b/backend-api/database/migrations/2025_07_09_000000_add_is_always_in_stock_to_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->boolean('is_always_in_stock')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('is_always_in_stock');
+        });
+    }
+};

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -73,6 +73,7 @@
     "addedToCart": "تمت إضافته إلى السلة",
     "out_of_stock": "غير متوفر",
     "outOfStock": "غير متوفر",
+    "inStock": "متوفر",
     "price": "السعر",
     "wholesale_price": "سعر الجملة",
     "wholesale_threshold": "حد الجملة",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -70,6 +70,7 @@
     "search": "Search products...",
     "add_to_cart": "Add to Cart",
     "out_of_stock": "Out of Stock",
+    "inStock": "In Stock",
     "price": "Price",
     "wholesale_price": "Wholesale Price",
     "wholesale_threshold": "Wholesale Threshold",

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -22,6 +22,7 @@ interface Product {
   wholesale_price?: string;
   wholesale_threshold?: number;
   stock: number;
+  is_always_in_stock: boolean;
   category?: {
     id: number;
     name: string;
@@ -102,7 +103,7 @@ const Products = () => {
       wholesale_price: product.wholesale_price ? parseFloat(product.wholesale_price) : undefined,
       wholesale_threshold: product.wholesale_threshold,
       image_url: product.image_url,
-      stock: product.stock
+      stock: product.is_always_in_stock ? 999 : product.stock
     };
 
     addToCart(cartProduct);
@@ -246,7 +247,11 @@ const Products = () => {
                     )}
                   </div>
                   <span className="text-xs text-gray-500">
-                    {t('products.stock')}: {product.stock}
+                    {product.is_always_in_stock
+                      ? product.stock > 0
+                        ? t('products.inStock')
+                        : t('products.outOfStock')
+                      : `${t('products.stock')}: ${product.stock}`}
                   </span>
                 </div>
 


### PR DESCRIPTION
This commit introduces the following changes:

- Adds an `is_always_in_stock` boolean attribute to the `Product` model.
- Modifies the frontend to display 'In stock' or 'Out of stock' for products based on the new attribute.
- Updates the cart logic to handle always-in-stock products.